### PR TITLE
local

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -13,15 +13,12 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showScanner, setShowScanner] = useState(false);
-  const [showManualEntry, setShowManualEntry] = useState(false);
-
-  // Handle direct URL access with chipID
-  useEffect(() => {
-    const chipID = searchParams.get('chipID');
-    if (chipID && /^P\d{5}$/.test(chipID)) {
-      setShowManualEntry(true);
-    }
-  }, [searchParams]);
+  
+  // Initialize showManualEntry based on URL params
+  const chipID = searchParams.get('chipID');
+  const [showManualEntry, setShowManualEntry] = useState(
+    Boolean(chipID && /^P\d{5}$/.test(chipID))
+  );
 
   const fetchSamples = async () => {
     try {
@@ -103,7 +100,7 @@ export default function Dashboard() {
           }
         }}
         onSubmit={handleSampleRegistration}
-        initialChipId={searchParams.get('chipID') || ''}
+        initialChipId={chipID || ''}
       />
 
       <Toaster position="top-right" />


### PR DESCRIPTION
- **Front end styling in progress. No connection to backend yet.**
- **Front end in progress. No backend connection.**
- **v1.9 -  Fully functional React overhaul of Onebreathpilot**
- **v1.9.5 - pre-deployment  configuration edits**
- **v1.9.99 - Netlify deployment config fixes**
- **netlify.toml production fixes**
- **production finishing touches to metadata, titles, logos, etc**
- **image src link fixed**
- **logo styling edits**
- **logo loading fixes**
- **file structure adjustments for images in assets**
- **image assets file restructing for static access**
- **images**
- **images source**
- **v2.0.1 - pick up form logic updated and QR scanner implementation updated**
- **dashboard main page formatting and styling updates for uniformity**
- **qr scan fix attempt**
- **Render backend deployment prep and attempt 1**
- **env variable use tweak in config.py**
- **Render server deployment fixes and attempt 2**
- **Render deployment fixes and reattempt 3**
- **Render server deployment fixes, restructuring and retry 4**
- **Render fix and retry 5**
- **Render deployment requirements.txt and version updates. retry 6**
- **render deployment fixes. retry 7**
- **Netlify deploy fixes after Render server deploy success**
- **Netlify deploy build fix retry 2**
- **netlify.toml file update for build**
- **Netlify build fixes retry 4**
- **api calls fix**
- **Successfully connected Re**
- **Firebase auth implemented and logic established. Fully functional.**
- **Data Viewer page loading fixes**
- **data visualization loading fix**
- **QR scanner implementation fixed and functioning on desktop and mobile. UI still needs work and logic testing.**
- **QR scanner now fully styled, implemented, and functional.**
- **netlify build fix**
- **connection to OpenAI API fix for AI insights. Attempt 1**
- **OpenAI connection fix attempt 2**
- **OpenAI connection fix attempt 3**
- **OpenAI connection fix attempt 5**
- **OpenAI connection fix attempt 6**
- **OpenAI connection fix attempt 7**
- **New OpenAI integration - SynopsisGPT attempt 1**
- **frontend backend cohesion fixes**
- **openai connection fixes**
- **dependency updates**
- **server updates and fixes for openai and CORS**
- **CORS fixes for data page**
- **dashboard button text change**
- **button styling fixes for readability**
- **dev config**
- **pickup form front and backend implementation**
- **pickup form styling**
- **styling adjustments for pickup fields**
- **pickup form input field settings**
- **refresh and auto load sample status update possubimit**
- **sample card timer added and content adjustments**
- **card  condition Updates**
- **timer updates**
- **timer font**
- **error code column added to completed table**
- **test for changing location to sample type across front and back end**
- **sample type verbage change to LC Positive/Negative**
- **download dataset button function implemented with excel file download**
- **openpyxl CSP fixes**
- **CSP fixes**
- **CSP fixes**
- **pandas dep for netlify fix**
- **server edits for deploy**
- **document writing on server fix**
- **data parsing on download fix**
- **domain changeover**
- **CORS fixes for v2 domain shift**
- **completed samples table styling and formating changes**
- **logic to handle location or sample type**
- **final volume completed samples table display formatting update**
- **completed samples table column order changed**
- **completed samples table completed data format change**
- **completed samples view sorting toggle and default views added**
- **mobile styling updated for download dataset button**
- **default completed samples view changed to table. qr code scanner camera permissions bug fixes**
- **qr code scanner styling changes**
- **scanner mobile styling fixes**
- **qr code scanner default ui removal and style fixes**
- **qr scanner overlay changed to qr box**
- **mobile scanner overlay fix**
- **registration form auto popup and autofill via url params fix**
- **registration form auto popup with url params fix 2**
- **auto popup fix**
- **auto popup fix reattempt**
- **popup reattempt**
